### PR TITLE
Do not leave NickServ window open after authentication

### DIFF
--- a/nickserv_osx_keychain.pl
+++ b/nickserv_osx_keychain.pl
@@ -28,7 +28,7 @@ sub cmd_identify {
       Irssi::print("Unable to retrieve password for account '$data':\n$password", MSGLEVEL_CLIENTERROR);
       return;
     }
-    $server->command("MSG NickServ identify $password");
+    $server->command("^MSG NickServ identify $password");
     Irssi::print("Sent identification for $data to NickServ.", MSGLEVEL_CLIENTNOTICE);
   } else {
     Irssi::print("Account name required.", MSGLEVEL_CLIENTERROR);


### PR DESCRIPTION
When prefixing MSG with a caret (`^`), irssi will not keep an extra window open. Turns out this is a much simpler fix for #1 than trying to use the irssi scripting API.
